### PR TITLE
feat(pr-ops): Grok-native MCP tool loop for conductor-gateway

### DIFF
--- a/pr-ops/06-mcp/mattermost-mcp.yaml
+++ b/pr-ops/06-mcp/mattermost-mcp.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mattermost-mcp
+  namespace: pr-ops
+  labels:
+    app: mattermost-mcp
+    app.kubernetes.io/part-of: pr-ops
+    app.kubernetes.io/component: mcp-server
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: mattermost-mcp
+  template:
+    metadata:
+      labels:
+        app: mattermost-mcp
+        app.kubernetes.io/part-of: pr-ops
+        app.kubernetes.io/component: mcp-server
+    spec:
+      imagePullSecrets:
+        - name: ghcr-connectplatform-ring
+      containers:
+        - name: mattermost-mcp
+          image: ghcr.io/connectplatform/ring/pr-ops/mattermost-mcp:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3200
+          env:
+            - name: PORT
+              value: "3200"
+            - name: MATTERMOST_URL
+              value: https://chat.ringdom.org
+            - name: MATTERMOST_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: pr-ops-credentials
+                  key: MATTERMOST_BOT_TOKEN
+            - name: MATTERMOST_APPROVAL_WEBHOOK
+              valueFrom:
+                secretKeyRef:
+                  name: pr-ops-credentials
+                  key: MATTERMOST_APPROVAL_WEBHOOK
+            - name: MATTERMOST_CRISIS_WEBHOOK
+              valueFrom:
+                secretKeyRef:
+                  name: pr-ops-credentials
+                  key: MATTERMOST_CRISIS_WEBHOOK
+            - name: MATTERMOST_AGENT_LOG_WEBHOOK
+              valueFrom:
+                secretKeyRef:
+                  name: pr-ops-credentials
+                  key: MATTERMOST_AGENT_LOG_WEBHOOK
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3200
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3200
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 25m
+              memory: 96Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mattermost-mcp
+  namespace: pr-ops
+  labels:
+    app.kubernetes.io/part-of: pr-ops
+    app.kubernetes.io/component: mcp-server
+spec:
+  type: ClusterIP
+  selector:
+    app: mattermost-mcp
+  ports:
+    - name: http
+      port: 3200
+      targetPort: 3200

--- a/pr-ops/06-mcp/outline-mcp.yaml
+++ b/pr-ops/06-mcp/outline-mcp.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: outline-mcp
+  namespace: pr-ops
+  labels:
+    app: outline-mcp
+    app.kubernetes.io/part-of: pr-ops
+    app.kubernetes.io/component: mcp-server
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: outline-mcp
+  template:
+    metadata:
+      labels:
+        app: outline-mcp
+        app.kubernetes.io/part-of: pr-ops
+        app.kubernetes.io/component: mcp-server
+    spec:
+      imagePullSecrets:
+        - name: ghcr-connectplatform-ring
+      containers:
+        - name: outline-mcp
+          image: ghcr.io/connectplatform/ring/pr-ops/outline-mcp:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3100
+          env:
+            - name: PORT
+              value: "3100"
+            - name: OUTLINE_API_URL
+              value: http://outline.pr-ops.svc.cluster.local:3000
+            - name: OUTLINE_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: pr-ops-credentials
+                  key: OUTLINE_API_TOKEN
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3100
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3100
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 25m
+              memory: 96Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: outline-mcp
+  namespace: pr-ops
+  labels:
+    app.kubernetes.io/part-of: pr-ops
+    app.kubernetes.io/component: mcp-server
+spec:
+  type: ClusterIP
+  selector:
+    app: outline-mcp
+  ports:
+    - name: http
+      port: 3100
+      targetPort: 3100

--- a/pr-ops/06-mcp/temporal-mcp.yaml
+++ b/pr-ops/06-mcp/temporal-mcp.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: temporal-mcp
+  namespace: pr-ops
+  labels:
+    app: temporal-mcp
+    app.kubernetes.io/part-of: pr-ops
+    app.kubernetes.io/component: mcp-server
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: temporal-mcp
+  template:
+    metadata:
+      labels:
+        app: temporal-mcp
+        app.kubernetes.io/part-of: pr-ops
+        app.kubernetes.io/component: mcp-server
+    spec:
+      imagePullSecrets:
+        - name: ghcr-connectplatform-ring
+      containers:
+        - name: temporal-mcp
+          image: ghcr.io/connectplatform/ring/pr-ops/temporal-mcp:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3300
+          env:
+            - name: PORT
+              value: "3300"
+            - name: TEMPORAL_ADDRESS
+              value: temporal-frontend.pr-ops.svc.cluster.local:7233
+            - name: TEMPORAL_NAMESPACE
+              value: pr-ops
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3300
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3300
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 25m
+              memory: 96Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: temporal-mcp
+  namespace: pr-ops
+  labels:
+    app.kubernetes.io/part-of: pr-ops
+    app.kubernetes.io/component: mcp-server
+spec:
+  type: ClusterIP
+  selector:
+    app: temporal-mcp
+  ports:
+    - name: http
+      port: 3300
+      targetPort: 3300

--- a/pr-ops/06-mcp/twenty-mcp.yaml
+++ b/pr-ops/06-mcp/twenty-mcp.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: twenty-mcp
+  namespace: pr-ops
+  labels:
+    app: twenty-mcp
+    app.kubernetes.io/part-of: pr-ops
+    app.kubernetes.io/component: mcp-server
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: twenty-mcp
+  template:
+    metadata:
+      labels:
+        app: twenty-mcp
+        app.kubernetes.io/part-of: pr-ops
+        app.kubernetes.io/component: mcp-server
+    spec:
+      imagePullSecrets:
+        - name: ghcr-connectplatform-ring
+      containers:
+        - name: twenty-mcp
+          image: ghcr.io/connectplatform/ring/pr-ops/twenty-mcp:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 5008
+          env:
+            - name: PORT
+              value: "5008"
+            - name: TWENTY_API_URL
+              value: http://twenty-crm-server.pr-ops.svc.cluster.local:3000
+            - name: TWENTY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pr-ops-credentials
+                  key: TWENTY_API_KEY
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 5008
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 5008
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 25m
+              memory: 96Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: twenty-mcp
+  namespace: pr-ops
+  labels:
+    app.kubernetes.io/part-of: pr-ops
+    app.kubernetes.io/component: mcp-server
+spec:
+  type: ClusterIP
+  selector:
+    app: twenty-mcp
+  ports:
+    - name: http
+      port: 5008
+      targetPort: 5008

--- a/pr-ops/07-conductor.yaml
+++ b/pr-ops/07-conductor.yaml
@@ -1,0 +1,137 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: conductor-gateway
+  namespace: pr-ops
+  labels:
+    app: conductor-gateway
+    app.kubernetes.io/part-of: pr-ops
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: conductor-gateway
+  template:
+    metadata:
+      labels:
+        app: conductor-gateway
+        app.kubernetes.io/part-of: pr-ops
+    spec:
+      imagePullSecrets:
+        - name: ghcr-connectplatform-ring
+      containers:
+        - name: conductor-gateway
+          image: ghcr.io/connectplatform/ring/pr-ops/conductor-gateway:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 4000
+          envFrom:
+            - secretRef:
+                name: pr-ops-credentials
+          env:
+            - name: PORT
+              value: "4000"
+            - name: PLANE_WORKSPACE_SLUG
+              value: ringdom-pr
+            - name: ANTHROPIC_MODEL
+              value: claude-haiku-4-5-20251001
+            - name: XAI_MODEL
+              value: grok-3
+            - name: ENABLE_MCP_TOOLS
+              value: "true"
+            - name: XAI_TOOL_MAX_STEPS
+              value: "8"
+            - name: ENABLE_ANTHROPIC_REMOTE_MCP
+              value: "false"
+            - name: ENABLE_ANTHROPIC_MCP
+              value: "true"
+            - name: BOSS_SYSTEM_PROMPT
+              valueFrom:
+                configMapKeyRef:
+                  name: boss-system-prompt
+                  key: prompt
+            - name: TWENTY_MCP_URL
+              value: http://twenty-mcp.pr-ops.svc.cluster.local:5008/mcp
+            - name: PLANE_MCP_URL
+              value: "off"
+            - name: OUTLINE_MCP_URL
+              value: http://outline-mcp.pr-ops.svc.cluster.local:3100/mcp
+            - name: MATTERMOST_MCP_URL
+              value: http://mattermost-mcp.pr-ops.svc.cluster.local:3200/mcp
+            - name: TEMPORAL_MCP_URL
+              value: http://temporal-mcp.pr-ops.svc.cluster.local:3300/mcp
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 25m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: conductor-gateway
+  namespace: pr-ops
+  labels:
+    app.kubernetes.io/part-of: pr-ops
+spec:
+  type: ClusterIP
+  selector:
+    app: conductor-gateway
+  ports:
+    - name: http
+      port: 4000
+      targetPort: 4000
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: pr-ops-conductor-tls
+  namespace: pr-ops
+spec:
+  secretName: pr-ops-conductor-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+  dnsNames:
+    - conductor.ringdom.org
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: conductor-gateway
+  namespace: pr-ops
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - conductor.ringdom.org
+      secretName: pr-ops-conductor-tls
+  rules:
+    - host: conductor.ringdom.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: conductor-gateway
+                port:
+                  number: 4000

--- a/pr-ops/README.md
+++ b/pr-ops/README.md
@@ -1,0 +1,44 @@
+# Ring PR-Ops Conductor (Grok-native MCP)
+
+Open-source extract of the Ringdom PR-Ops **conductor-gateway** and ClusterIP MCP bridges (Twenty, Outline, Mattermost, Temporal).
+
+## Why this exists
+
+Anthropic hosted `mcp_servers` cannot reach Kubernetes ClusterIP URLs. This gateway:
+
+1. Discovers tools from in-cluster Streamable HTTP MCP servers
+2. Prefers **xAI Grok** via the OpenAI-compatible **Responses API** function calling
+3. Falls back to Anthropic Haiku on the same **local** tool loop
+4. Returns `tool_trace` on `/boss` and `/route`
+
+## Quick start (local)
+
+```bash
+cd conductor
+npm install && npm run build
+export XAI_API_KEY=...
+export ENABLE_MCP_TOOLS=true
+export TWENTY_MCP_URL=http://127.0.0.1:5008/mcp
+export PLANE_MCP_URL=off
+npm start
+curl -s localhost:4000/health | jq .
+```
+
+## Images
+
+`ghcr.io/connectplatform/ring/pr-ops/{conductor-gateway,twenty-mcp,outline-mcp,mattermost-mcp,temporal-mcp}:latest`
+
+## Env
+
+| Variable | Meaning |
+|---|---|
+| `XAI_API_KEY` | Prefer Grok when set |
+| `XAI_MODEL` | Default `grok-3` |
+| `ENABLE_MCP_TOOLS` | Local MCP catalog + tool loop |
+| `ENABLE_ANTHROPIC_REMOTE_MCP` | Experimental cloud MCP (not for ClusterIP) |
+| `PLANE_MCP_URL` | Set `off` until Plane MCP is deployed |
+| `ANTHROPIC_API_KEY` / `ANTHROPIC_MODEL` | Haiku fallback |
+
+## Security
+
+Keep MCP Services ClusterIP-only. Do not expose MCP Ingress publicly.

--- a/pr-ops/conductor/Dockerfile
+++ b/pr-ops/conductor/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+ENV PORT=4000
+EXPOSE 4000
+CMD ["npm", "start"]

--- a/pr-ops/conductor/package.json
+++ b/pr-ops/conductor/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "pr-ops-conductor-gateway",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "latest",
+    "@modelcontextprotocol/sdk": "latest",
+    "express": "latest",
+    "openai": "latest"
+  },
+  "devDependencies": {
+    "@types/express": "latest",
+    "@types/node": "latest",
+    "typescript": "latest"
+  }
+}

--- a/pr-ops/conductor/src/cli.ts
+++ b/pr-ops/conductor/src/cli.ts
@@ -1,0 +1,48 @@
+const conductorUrl = (process.env.CONDUCTOR_URL || 'http://conductor-gateway.pr-ops.svc.cluster.local:4000').replace(/\/$/, '');
+
+function arg(name: string, fallback = '') {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((value) => value.startsWith(prefix));
+  return found ? found.slice(prefix.length) : fallback;
+}
+
+async function main() {
+  const mode = arg('mode', 'route');
+  const inputType = arg('input-type', 'auto_classify');
+  const content = arg('content', '');
+  const metadataRaw = arg('metadata', '{}');
+
+  let metadata: unknown = {};
+  try {
+    metadata = JSON.parse(metadataRaw);
+  } catch {
+    metadata = { raw: metadataRaw };
+  }
+
+  const endpoint = mode === 'boss' ? '/boss' : '/route';
+  const body =
+    mode === 'boss'
+      ? { message: content, metadata }
+      : {
+          input_type: inputType,
+          content,
+          metadata
+        };
+
+  const response = await fetch(`${conductorUrl}${endpoint}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+
+  const text = await response.text();
+  console.log(text);
+  if (!response.ok) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/pr-ops/conductor/src/index.ts
+++ b/pr-ops/conductor/src/index.ts
@@ -1,0 +1,258 @@
+import express from 'express';
+import Anthropic from '@anthropic-ai/sdk';
+import OpenAI from 'openai';
+import { loadToolCatalog } from './mcp/catalog.js';
+import type { McpServerConfig } from './mcp/types.js';
+import { callAnthropicWithTools } from './providers/anthropic.js';
+import { callXaiWithTools } from './providers/xai.js';
+
+const port = Number(process.env.PORT || 4000);
+const anthropicApiKey = process.env.ANTHROPIC_API_KEY || '';
+const xaiApiKey = process.env.XAI_API_KEY || process.env.GROK_API_KEY || '';
+const systemPrompt =
+  process.env.BOSS_SYSTEM_PROMPT ||
+  'You are the Ringdom PR-Ops conductor. Route work through available tools and require human approval for risky actions.';
+
+/** Anthropic fallback — Launch policy: Haiku for all Anthropic calls */
+const anthropicModel = process.env.ANTHROPIC_MODEL || 'claude-haiku-4-5-20251001';
+/** Preferred when XAI_API_KEY is set */
+const xaiModel = process.env.XAI_MODEL || process.env.GROK_MODEL || 'grok-3';
+
+/**
+ * Provider-agnostic local MCP tools (ClusterIP-safe).
+ * ENABLE_ANTHROPIC_MCP remains a deprecated alias that also turns this on.
+ */
+const enableMcpTools =
+  process.env.ENABLE_MCP_TOOLS === 'true' || process.env.ENABLE_ANTHROPIC_MCP === 'true';
+/** Experimental only — Anthropic cloud cannot reach ClusterIP MCP URLs */
+const enableAnthropicRemoteMcp = process.env.ENABLE_ANTHROPIC_REMOTE_MCP === 'true';
+const maxToolSteps = Number(process.env.XAI_TOOL_MAX_STEPS || process.env.TOOL_MAX_STEPS || 8);
+const maxTokens = Number(process.env.XAI_MAX_TOKENS || process.env.ANTHROPIC_MAX_TOKENS || 4096);
+
+const preferXai = Boolean(xaiApiKey);
+const provider: 'xai' | 'anthropic' = preferXai ? 'xai' : 'anthropic';
+const activeModel = provider === 'xai' ? xaiModel : anthropicModel;
+
+if (provider === 'anthropic' && !anthropicApiKey) {
+  throw new Error('ANTHROPIC_API_KEY is required when XAI_API_KEY is not set');
+}
+if (provider === 'xai' && !xaiApiKey) {
+  throw new Error('XAI_API_KEY is required for xAI provider');
+}
+
+const anthropic = anthropicApiKey ? new Anthropic({ apiKey: anthropicApiKey }) : null;
+const xai = preferXai
+  ? new OpenAI({
+      apiKey: xaiApiKey,
+      baseURL: process.env.XAI_BASE_URL || 'https://api.x.ai/v1'
+    })
+  : null;
+
+const mcpServers: McpServerConfig[] = [
+  {
+    name: 'twenty-crm',
+    url: process.env.TWENTY_MCP_URL || 'http://twenty-mcp.pr-ops.svc.cluster.local:5008/mcp'
+  },
+  ...(process.env.PLANE_MCP_URL && process.env.PLANE_MCP_URL !== 'off'
+    ? [
+        {
+          name: 'plane-tasks',
+          url: process.env.PLANE_MCP_URL,
+          authorizationToken: process.env.PLANE_API_TOKEN || ''
+        } satisfies McpServerConfig
+      ]
+    : []),
+  {
+    name: 'outline-wiki',
+    url: process.env.OUTLINE_MCP_URL || 'http://outline-mcp.pr-ops.svc.cluster.local:3100/mcp'
+  },
+  {
+    name: 'mattermost-comms',
+    url: process.env.MATTERMOST_MCP_URL || 'http://mattermost-mcp.pr-ops.svc.cluster.local:3200/mcp'
+  },
+  {
+    name: 'temporal-workflows',
+    url: process.env.TEMPORAL_MCP_URL || 'http://temporal-mcp.pr-ops.svc.cluster.local:3300/mcp'
+  }
+];
+
+const remoteMcpServers = mcpServers.map((server) => ({
+  type: 'url' as const,
+  url: server.url,
+  name: server.name,
+  ...(server.authorizationToken ? { authorization_token: server.authorizationToken } : {})
+}));
+
+const INPUT_TYPES = [
+  'press_release_draft',
+  'pitch_email_draft',
+  'social_post_batch',
+  'journalist_research_note',
+  'brand_monitoring_alert',
+  'campaign_brief',
+  'newsletter_section',
+  'crisis_signal',
+  'coverage_confirmed',
+  'investor_update_draft',
+  'content_repurpose_job',
+  'okr_metric_update',
+  'auto_classify',
+  'newsletter_assembly',
+  'weekly_content_batch',
+  'approval_signal',
+  'pitch_replied'
+] as const;
+
+function routeSystemSuffix(inputType: string) {
+  return [
+    '',
+    '## CONDUCTOR ROUTE CONTRACT',
+    `input_type=${inputType}`,
+    'Classify against the 12-type taxonomy if input_type is auto_classify.',
+    'Canonical types: press_release_draft | pitch_email_draft | social_post_batch | journalist_research_note | brand_monitoring_alert | campaign_brief | newsletter_section | crisis_signal | coverage_confirmed | investor_update_draft | content_repurpose_job | okr_metric_update',
+    'If confidence < 0.8, recommend a Plane @blocked issue and halt risky routing.',
+    'CHECK INSTRUMENTS FIRST (Twenty, Plane, Outline) via tools before inventing work.',
+    'HUMAN GATES: wire / investor / crisis / third-party naming → Mattermost #pr-approvals tools.',
+    'CRISIS: pause scheduled content, notify #crisis-watch.'
+  ].join('\n');
+}
+
+async function conductorMessage(input: unknown, mode: 'route' | 'boss') {
+  const userContent =
+    mode === 'route' ? JSON.stringify(input) : String((input as { message?: unknown }).message ?? input);
+  const inputType =
+    mode === 'route'
+      ? String((input as { input_type?: string }).input_type || 'auto_classify')
+      : 'boss';
+  const system = mode === 'route' ? `${systemPrompt}${routeSystemSuffix(inputType)}` : systemPrompt;
+
+  const catalog = enableMcpTools
+    ? await loadToolCatalog(mcpServers)
+    : { tools: [], statuses: [], loadedAt: new Date().toISOString() };
+
+  if (provider === 'xai') {
+    if (!xai) throw new Error('xAI client not configured');
+    return callXaiWithTools({
+      client: xai,
+      model: xaiModel,
+      system,
+      userContent,
+      servers: mcpServers,
+      catalog: catalog.tools,
+      enableTools: enableMcpTools,
+      maxSteps: maxToolSteps,
+      maxTokens
+    });
+  }
+
+  if (!anthropic) throw new Error('Anthropic client not configured');
+  return callAnthropicWithTools({
+    client: anthropic,
+    model: anthropicModel,
+    system,
+    userContent,
+    servers: mcpServers,
+    catalog: catalog.tools,
+    enableTools: enableMcpTools,
+    enableRemoteMcp: enableAnthropicRemoteMcp && !enableMcpTools,
+    remoteMcpServers,
+    maxSteps: maxToolSteps,
+    maxTokens
+  });
+}
+
+const app = express();
+app.use(express.json({ limit: '4mb' }));
+
+app.get('/health', async (_req, res) => {
+  const catalog = enableMcpTools
+    ? await loadToolCatalog(mcpServers).catch((error) => ({
+        tools: [],
+        statuses: mcpServers.map((server) => ({
+          name: server.name,
+          url: server.url,
+          ok: false,
+          toolCount: 0,
+          error: error instanceof Error ? error.message : String(error)
+        })),
+        loadedAt: new Date().toISOString()
+      }))
+    : { tools: [], statuses: [], loadedAt: new Date().toISOString() };
+
+  res.json({
+    status: 'ok',
+    service: 'conductor-gateway',
+    provider,
+    model: activeModel,
+    anthropicModel,
+    xaiModel,
+    preferXai,
+    enableMcpTools,
+    enableAnthropicRemoteMcp,
+    mcpNote: enableMcpTools
+      ? 'Local ClusterIP MCP client + provider function calling (Grok Responses / Anthropic tools)'
+      : enableAnthropicRemoteMcp
+        ? 'Experimental Anthropic remote MCP (ClusterIP URLs will fail from Anthropic cloud)'
+        : 'MCP tools disabled — prompt-only routing',
+    mcpCatalogLoadedAt: catalog.loadedAt,
+    mcpToolCount: catalog.tools.length,
+    mcpServers: catalog.statuses.length
+      ? catalog.statuses
+      : mcpServers.map((server) => ({ name: server.name, url: server.url, ok: null, toolCount: null })),
+    inputTypes: INPUT_TYPES,
+    maxToolSteps
+  });
+});
+
+app.post('/route', async (req, res) => {
+  try {
+    const inputType = req.body?.input_type || 'auto_classify';
+    if (inputType !== 'auto_classify' && !(INPUT_TYPES as readonly string[]).includes(inputType)) {
+      res.status(400).json({
+        error: `Unknown input_type: ${inputType}`,
+        allowed: INPUT_TYPES
+      });
+      return;
+    }
+    const response = await conductorMessage(
+      {
+        input_type: inputType,
+        content: req.body?.content,
+        metadata: req.body?.metadata || {}
+      },
+      'route'
+    );
+    res.json({
+      routing_result: response.content,
+      usage: response.usage,
+      stop_reason: response.stop_reason,
+      provider: response.provider,
+      model: response.model,
+      tool_trace: response.tool_trace
+    });
+  } catch (error) {
+    res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
+  }
+});
+
+app.post('/boss', async (req, res) => {
+  try {
+    const response = await conductorMessage(req.body, 'boss');
+    res.json({
+      response: response.content,
+      usage: response.usage,
+      stop_reason: response.stop_reason,
+      provider: response.provider,
+      model: response.model,
+      tool_trace: response.tool_trace
+    });
+  } catch (error) {
+    res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
+  }
+});
+
+app.listen(port, () => {
+  console.log(
+    `conductor-gateway listening on :${port} provider=${provider} model=${activeModel} mcpTools=${enableMcpTools} remoteAnthropicMcp=${enableAnthropicRemoteMcp}`
+  );
+});

--- a/pr-ops/conductor/src/mcp/catalog.ts
+++ b/pr-ops/conductor/src/mcp/catalog.ts
@@ -1,0 +1,75 @@
+import { listServerTools } from './client.js';
+import type { CatalogTool, McpServerConfig, McpServerStatus } from './types.js';
+
+export type CatalogSnapshot = {
+  tools: CatalogTool[];
+  statuses: McpServerStatus[];
+  loadedAt: string;
+};
+
+let cache: CatalogSnapshot | null = null;
+let cacheExpiresAt = 0;
+
+export async function loadToolCatalog(
+  servers: McpServerConfig[],
+  options?: { force?: boolean; ttlMs?: number }
+): Promise<CatalogSnapshot> {
+  const ttlMs = options?.ttlMs ?? Number(process.env.MCP_CATALOG_TTL_MS || 60_000);
+  const now = Date.now();
+  if (!options?.force && cache && now < cacheExpiresAt) {
+    return cache;
+  }
+
+  const statuses: McpServerStatus[] = [];
+  const tools: CatalogTool[] = [];
+
+  await Promise.all(
+    servers.map(async (server) => {
+      try {
+        const listed = await listServerTools(server);
+        tools.push(...listed);
+        statuses.push({
+          name: server.name,
+          url: server.url,
+          ok: true,
+          toolCount: listed.length
+        });
+      } catch (error) {
+        statuses.push({
+          name: server.name,
+          url: server.url,
+          ok: false,
+          toolCount: 0,
+          error: error instanceof Error ? error.message : String(error)
+        });
+        console.warn(
+          `[conductor] MCP catalog skip ${server.name}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+    })
+  );
+
+  cache = { tools, statuses, loadedAt: new Date().toISOString() };
+  cacheExpiresAt = now + ttlMs;
+  return cache;
+}
+
+export function toXaiFunctionTools(tools: CatalogTool[]) {
+  return tools.map((tool) => ({
+    type: 'function' as const,
+    name: tool.name,
+    description: tool.description,
+    parameters: tool.parameters,
+    strict: false as const
+  }));
+}
+
+export function toAnthropicTools(tools: CatalogTool[]) {
+  return tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    input_schema: tool.parameters
+  }));
+}

--- a/pr-ops/conductor/src/mcp/client.ts
+++ b/pr-ops/conductor/src/mcp/client.ts
@@ -1,0 +1,158 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { CatalogTool, McpServerConfig, ToolTraceEntry } from './types.js';
+
+function preview(value: unknown, max = 500): string {
+  const text = typeof value === 'string' ? value : JSON.stringify(value);
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+function extractText(result: unknown): string {
+  if (!result || typeof result !== 'object') return String(result ?? '');
+  const content = (result as { content?: unknown }).content;
+  if (!Array.isArray(content)) return JSON.stringify(result);
+  return content
+    .map((part) => {
+      if (part && typeof part === 'object' && 'text' in part) {
+        return String((part as { text: unknown }).text);
+      }
+      return JSON.stringify(part);
+    })
+    .join('\n');
+}
+
+async function withClient<T>(
+  server: McpServerConfig,
+  fn: (client: Client) => Promise<T>
+): Promise<T> {
+  const headers: Record<string, string> = {
+    Accept: 'application/json, text/event-stream'
+  };
+  if (server.authorizationToken) {
+    headers.Authorization = `Bearer ${server.authorizationToken}`;
+  }
+  const transport = new StreamableHTTPClientTransport(new URL(server.url), {
+    requestInit: { headers }
+  });
+  const client = new Client({ name: 'conductor-gateway', version: '0.2.0' });
+  await client.connect(transport);
+  try {
+    return await fn(client);
+  } finally {
+    try {
+      await client.close();
+    } catch {
+      /* ignore close races */
+    }
+  }
+}
+
+export async function listServerTools(server: McpServerConfig): Promise<CatalogTool[]> {
+  return withClient(server, async (client) => {
+    const listed = await client.listTools();
+    return (listed.tools || []).map((tool) => {
+      const parameters =
+        tool.inputSchema && typeof tool.inputSchema === 'object'
+          ? (tool.inputSchema as Record<string, unknown>)
+          : { type: 'object', properties: {} };
+      if (!parameters.type) parameters.type = 'object';
+      return {
+        name: `${server.name}__${tool.name}`,
+        serverName: server.name,
+        toolName: tool.name,
+        description: `[${server.name}] ${tool.description || tool.name}`,
+        parameters
+      };
+    });
+  });
+}
+
+export async function callServerTool(
+  server: McpServerConfig,
+  toolName: string,
+  args: Record<string, unknown>
+): Promise<{ text: string; raw: unknown }> {
+  return withClient(server, async (client) => {
+    const raw = await client.callTool({ name: toolName, arguments: args });
+    return { text: extractText(raw), raw };
+  });
+}
+
+export function parseNamespacedTool(name: string): { serverName: string; toolName: string } | null {
+  const idx = name.indexOf('__');
+  if (idx <= 0) return null;
+  return { serverName: name.slice(0, idx), toolName: name.slice(idx + 2) };
+}
+
+export async function dispatchCatalogTool(
+  servers: McpServerConfig[],
+  catalog: CatalogTool[],
+  namespacedName: string,
+  argsJson: string
+): Promise<ToolTraceEntry & { output: string }> {
+  const started = Date.now();
+  const parsed = parseNamespacedTool(namespacedName);
+  if (!parsed) {
+    return {
+      server: 'unknown',
+      tool: namespacedName,
+      arguments: argsJson,
+      ok: false,
+      durationMs: Date.now() - started,
+      error: `Invalid namespaced tool: ${namespacedName}`,
+      output: JSON.stringify({ error: `Invalid namespaced tool: ${namespacedName}` })
+    };
+  }
+  const server = servers.find((s) => s.name === parsed.serverName);
+  const inCatalog = catalog.some(
+    (t) => t.serverName === parsed.serverName && t.toolName === parsed.toolName
+  );
+  if (!server || !inCatalog) {
+    return {
+      server: parsed.serverName,
+      tool: parsed.toolName,
+      arguments: argsJson,
+      ok: false,
+      durationMs: Date.now() - started,
+      error: `Unknown tool ${namespacedName}`,
+      output: JSON.stringify({ error: `Unknown tool ${namespacedName}` })
+    };
+  }
+  let args: Record<string, unknown> = {};
+  try {
+    args = argsJson ? (JSON.parse(argsJson) as Record<string, unknown>) : {};
+  } catch (error) {
+    return {
+      server: parsed.serverName,
+      tool: parsed.toolName,
+      arguments: argsJson,
+      ok: false,
+      durationMs: Date.now() - started,
+      error: `Invalid JSON arguments: ${error instanceof Error ? error.message : String(error)}`,
+      output: JSON.stringify({ error: 'Invalid JSON arguments' })
+    };
+  }
+  try {
+    const { text } = await callServerTool(server, parsed.toolName, args);
+    return {
+      server: parsed.serverName,
+      tool: parsed.toolName,
+      arguments: args,
+      ok: true,
+      durationMs: Date.now() - started,
+      resultPreview: preview(text),
+      output: text
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      server: parsed.serverName,
+      tool: parsed.toolName,
+      arguments: args,
+      ok: false,
+      durationMs: Date.now() - started,
+      error: message,
+      output: JSON.stringify({ error: message })
+    };
+  }
+}

--- a/pr-ops/conductor/src/mcp/types.ts
+++ b/pr-ops/conductor/src/mcp/types.ts
@@ -1,0 +1,41 @@
+export type McpServerConfig = {
+  name: string;
+  url: string;
+  authorizationToken?: string;
+};
+
+export type CatalogTool = {
+  /** Namespaced name: `{server}__{tool}` */
+  name: string;
+  serverName: string;
+  toolName: string;
+  description: string;
+  parameters: Record<string, unknown>;
+};
+
+export type ToolTraceEntry = {
+  server: string;
+  tool: string;
+  arguments: unknown;
+  ok: boolean;
+  durationMs: number;
+  error?: string;
+  resultPreview?: string;
+};
+
+export type McpServerStatus = {
+  name: string;
+  url: string;
+  ok: boolean;
+  toolCount: number;
+  error?: string;
+};
+
+export type ConductorResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  usage: unknown;
+  stop_reason: string | null;
+  provider: 'xai' | 'anthropic';
+  model: string;
+  tool_trace: ToolTraceEntry[];
+};

--- a/pr-ops/conductor/src/providers/anthropic.ts
+++ b/pr-ops/conductor/src/providers/anthropic.ts
@@ -1,0 +1,138 @@
+import type Anthropic from '@anthropic-ai/sdk';
+import { dispatchCatalogTool } from '../mcp/client.js';
+import { toAnthropicTools } from '../mcp/catalog.js';
+import type { CatalogTool, ConductorResult, McpServerConfig, ToolTraceEntry } from '../mcp/types.js';
+
+type ContentBlock = Anthropic.Messages.ContentBlock;
+type MessageParam = Anthropic.Messages.MessageParam;
+
+function textFromContent(content: ContentBlock[]): string {
+  return content
+    .filter((block): block is Anthropic.Messages.TextBlock => block.type === 'text')
+    .map((block) => block.text)
+    .join('\n');
+}
+
+export async function callAnthropicWithTools(params: {
+  client: Anthropic;
+  model: string;
+  system: string;
+  userContent: string;
+  servers: McpServerConfig[];
+  catalog: CatalogTool[];
+  enableTools: boolean;
+  /** Deprecated: Anthropic cloud remote MCP — ClusterIP unreachable; keep off in Ringdom */
+  enableRemoteMcp: boolean;
+  remoteMcpServers: Array<{
+    type: 'url';
+    url: string;
+    name: string;
+    authorization_token?: string;
+  }>;
+  maxSteps: number;
+  maxTokens: number;
+}): Promise<ConductorResult> {
+  const tool_trace: ToolTraceEntry[] = [];
+  const localTools =
+    params.enableTools && params.catalog.length > 0 ? toAnthropicTools(params.catalog) : undefined;
+
+  const system: Anthropic.Messages.MessageCreateParams['system'] = [
+    {
+      type: 'text',
+      text: params.system,
+      cache_control: { type: 'ephemeral' }
+    }
+  ];
+
+  const messages: MessageParam[] = [{ role: 'user', content: params.userContent }];
+
+  // Remote MCP only for experimental public MCP URLs — not ClusterIP.
+  if (params.enableRemoteMcp && !localTools) {
+    const response = await (params.client.beta.messages.create as any)(
+      {
+        model: params.model,
+        max_tokens: params.maxTokens,
+        system,
+        messages,
+        mcp_servers: params.remoteMcpServers,
+        tools: params.remoteMcpServers.map((server) => ({
+          type: 'mcp_toolset',
+          mcp_server_name: server.name
+        }))
+      },
+      {
+        headers: {
+          'anthropic-beta': process.env.ANTHROPIC_BETA || 'mcp-client-2025-11-20'
+        }
+      }
+    );
+    return {
+      content: response.content,
+      usage: response.usage,
+      stop_reason: response.stop_reason,
+      provider: 'anthropic',
+      model: params.model,
+      tool_trace
+    };
+  }
+
+  let response = await params.client.messages.create({
+    model: params.model,
+    max_tokens: params.maxTokens,
+    system,
+    messages,
+    ...(localTools ? { tools: localTools as Anthropic.Messages.Tool[] } : {})
+  });
+
+  let steps = 0;
+  while (response.stop_reason === 'tool_use' && steps < params.maxSteps) {
+    steps += 1;
+    const toolUses = response.content.filter(
+      (block): block is Anthropic.Messages.ToolUseBlock => block.type === 'tool_use'
+    );
+    const toolResults: Anthropic.Messages.ToolResultBlockParam[] = [];
+    for (const use of toolUses) {
+      const dispatched = await dispatchCatalogTool(
+        params.servers,
+        params.catalog,
+        use.name,
+        JSON.stringify(use.input ?? {})
+      );
+      tool_trace.push({
+        server: dispatched.server,
+        tool: dispatched.tool,
+        arguments: dispatched.arguments,
+        ok: dispatched.ok,
+        durationMs: dispatched.durationMs,
+        error: dispatched.error,
+        resultPreview: dispatched.resultPreview
+      });
+      toolResults.push({
+        type: 'tool_result',
+        tool_use_id: use.id,
+        content: dispatched.output,
+        is_error: !dispatched.ok
+      });
+    }
+
+    messages.push({ role: 'assistant', content: response.content });
+    messages.push({ role: 'user', content: toolResults });
+
+    response = await params.client.messages.create({
+      model: params.model,
+      max_tokens: params.maxTokens,
+      system,
+      messages,
+      ...(localTools ? { tools: localTools as Anthropic.Messages.Tool[] } : {})
+    });
+  }
+
+  return {
+    content: [{ type: 'text', text: textFromContent(response.content) }],
+    usage: response.usage,
+    stop_reason: response.stop_reason,
+    provider: 'anthropic',
+    model: params.model,
+    tool_trace
+  };
+}

--- a/pr-ops/conductor/src/providers/xai.ts
+++ b/pr-ops/conductor/src/providers/xai.ts
@@ -1,0 +1,97 @@
+import type OpenAI from 'openai';
+import { dispatchCatalogTool } from '../mcp/client.js';
+import { toXaiFunctionTools } from '../mcp/catalog.js';
+import type { CatalogTool, ConductorResult, McpServerConfig, ToolTraceEntry } from '../mcp/types.js';
+
+function extractOutputText(response: OpenAI.Responses.Response): string {
+  const chunks: string[] = [];
+  for (const item of response.output || []) {
+    if (item.type === 'message') {
+      for (const part of item.content || []) {
+        if (part.type === 'output_text') chunks.push(part.text);
+      }
+    }
+  }
+  if (chunks.length) return chunks.join('\n');
+  return response.output_text || '';
+}
+
+export async function callXaiWithTools(params: {
+  client: OpenAI;
+  model: string;
+  system: string;
+  userContent: string;
+  servers: McpServerConfig[];
+  catalog: CatalogTool[];
+  enableTools: boolean;
+  maxSteps: number;
+  maxTokens: number;
+}): Promise<ConductorResult> {
+  const tool_trace: ToolTraceEntry[] = [];
+  const tools =
+    params.enableTools && params.catalog.length > 0 ? toXaiFunctionTools(params.catalog) : undefined;
+
+  let response = await params.client.responses.create({
+    model: params.model,
+    max_output_tokens: params.maxTokens,
+    instructions: params.system,
+    input: [{ role: 'user', content: params.userContent }],
+    ...(tools ? { tools } : {})
+  });
+
+  let steps = 0;
+  while (steps < params.maxSteps) {
+    const functionCalls = (response.output || []).filter(
+      (item): item is OpenAI.Responses.ResponseFunctionToolCall => item.type === 'function_call'
+    );
+    if (!functionCalls.length) break;
+    steps += 1;
+
+    const outputs: Array<{
+      type: 'function_call_output';
+      call_id: string;
+      output: string;
+    }> = [];
+
+    for (const call of functionCalls) {
+      const dispatched = await dispatchCatalogTool(
+        params.servers,
+        params.catalog,
+        call.name,
+        call.arguments || '{}'
+      );
+      tool_trace.push({
+        server: dispatched.server,
+        tool: dispatched.tool,
+        arguments: dispatched.arguments,
+        ok: dispatched.ok,
+        durationMs: dispatched.durationMs,
+        error: dispatched.error,
+        resultPreview: dispatched.resultPreview
+      });
+      outputs.push({
+        type: 'function_call_output',
+        call_id: call.call_id,
+        output: dispatched.output
+      });
+    }
+
+    response = await params.client.responses.create({
+      model: params.model,
+      max_output_tokens: params.maxTokens,
+      previous_response_id: response.id,
+      input: outputs,
+      ...(tools ? { tools } : {})
+    });
+  }
+
+  const text = extractOutputText(response);
+  return {
+    content: [{ type: 'text', text }],
+    usage: response.usage,
+    stop_reason: response.status ?? null,
+    provider: 'xai',
+    model: params.model,
+    tool_trace
+  };
+}

--- a/pr-ops/conductor/tsconfig.json
+++ b/pr-ops/conductor/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pr-ops/mcp/mattermost-mcp/Dockerfile
+++ b/pr-ops/mcp/mattermost-mcp/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+ENV PORT=3200
+EXPOSE 3200
+CMD ["npm", "start"]

--- a/pr-ops/mcp/mattermost-mcp/package.json
+++ b/pr-ops/mcp/mattermost-mcp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "pr-ops-mattermost-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "latest",
+    "express": "latest",
+    "zod": "latest"
+  },
+  "devDependencies": {
+    "@types/express": "latest",
+    "@types/node": "latest",
+    "typescript": "latest"
+  }
+}

--- a/pr-ops/mcp/mattermost-mcp/src/index.ts
+++ b/pr-ops/mcp/mattermost-mcp/src/index.ts
@@ -1,0 +1,151 @@
+import express from 'express';
+import { randomUUID } from 'node:crypto';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { z } from 'zod';
+
+const port = Number(process.env.PORT || 3200);
+const botToken = process.env.MATTERMOST_BOT_TOKEN;
+const mattermostUrl = (process.env.MATTERMOST_URL || 'https://chat.ringdom.org').replace(/\/$/, '');
+const webhookMap = {
+  approvals: process.env.MATTERMOST_APPROVAL_WEBHOOK,
+  crisis: process.env.MATTERMOST_CRISIS_WEBHOOK,
+  agent_log: process.env.MATTERMOST_AGENT_LOG_WEBHOOK
+};
+const signals = new Map<string, { decision: string; payload: unknown; createdAt: string }>();
+
+function asContent(value: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] };
+}
+
+async function postWebhook(url: string | undefined, message: Record<string, unknown>) {
+  if (!url) throw new Error('Mattermost webhook URL is not configured');
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(message)
+  });
+  if (!response.ok) {
+    throw new Error(`Mattermost webhook ${response.status}: ${await response.text()}`);
+  }
+  return { ok: true };
+}
+
+function createServer() {
+  const server = new McpServer(
+    { name: 'mattermost-comms', version: '0.1.1' },
+    {
+      instructions:
+        'Use Mattermost tools for approval requests, crisis alerts, and immutable agent action logs. Investor or crisis communications must go through approvals.'
+    }
+  );
+
+  server.registerTool(
+    'mm_post_approval_request',
+    {
+      title: 'Post Approval Request',
+      description: 'Post a human approval request to Mattermost #pr-approvals.',
+      inputSchema: {
+        title: z.string(),
+        summary: z.string(),
+        consequence: z.string().optional(),
+        approve_payload: z.record(z.string(), z.unknown()).optional(),
+        reject_payload: z.record(z.string(), z.unknown()).optional()
+      }
+    },
+    async ({ title, summary, consequence, approve_payload, reject_payload }) => {
+      const requestId = randomUUID();
+      await postWebhook(webhookMap.approvals, {
+        text: `### Approval Required: ${title}\n\n${summary}\n\n${consequence ? `Consequence: ${consequence}\n\n` : ''}Request ID: \`${requestId}\``,
+        props: { requestId, approve_payload, reject_payload }
+      });
+      return asContent({ requestId, posted: true });
+    }
+  );
+
+  server.registerTool(
+    'mm_post_alert',
+    {
+      title: 'Post Alert',
+      description: 'Post an alert to crisis-watch or media-coverage-alerts via configured webhook.',
+      inputSchema: {
+        tier: z.enum(['info', 'warning', 'crisis']).default('info'),
+        message: z.string()
+      }
+    },
+    async ({ tier, message }) =>
+      asContent(
+        await postWebhook(tier === 'crisis' ? webhookMap.crisis : webhookMap.agent_log, {
+          text: `[${tier.toUpperCase()}] ${message}`
+        })
+      )
+  );
+
+  server.registerTool(
+    'mm_post_agent_log',
+    {
+      title: 'Post Agent Log',
+      description: 'Log an autonomous agent action to Mattermost #agent-log.',
+      inputSchema: {
+        action: z.string(),
+        result: z.string(),
+        metadata: z.record(z.string(), z.unknown()).optional()
+      }
+    },
+    async ({ action, result, metadata }) =>
+      asContent(
+        await postWebhook(webhookMap.agent_log, {
+          text: `Agent action: **${action}**\nResult: ${result}`,
+          props: metadata
+        })
+      )
+  );
+
+  server.registerTool(
+    'mm_await_signal',
+    {
+      title: 'Await Mattermost Signal',
+      description: 'Return a previously captured callback signal by request id.',
+      inputSchema: {
+        request_id: z.string()
+      }
+    },
+    async ({ request_id }) => asContent(signals.get(request_id) ?? { request_id, found: false })
+  );
+
+  return server;
+}
+
+const app = express();
+app.use(express.json({ limit: '2mb' }));
+app.get('/health', (_req, res) => res.json({ status: 'ok', service: 'mattermost-mcp' }));
+app.post('/callback', (req, res) => {
+  const requestId = String(req.body?.request_id || req.body?.context?.requestId || randomUUID());
+  signals.set(requestId, {
+    decision: String(req.body?.decision || req.body?.context?.action || 'unknown'),
+    payload: req.body,
+    createdAt: new Date().toISOString()
+  });
+  res.json({ ok: true, requestId });
+});
+app.post('/mcp', async (req, res) => {
+  try {
+    const server = createServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true
+    });
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    if (!res.headersSent) {
+      res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
+    }
+  }
+});
+
+app.listen(port, () => {
+  console.log(
+    `mattermost-mcp listening on :${port}; Mattermost base ${mattermostUrl}; bot token configured=${Boolean(botToken)}`
+  );
+});

--- a/pr-ops/mcp/mattermost-mcp/tsconfig.json
+++ b/pr-ops/mcp/mattermost-mcp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pr-ops/mcp/outline-mcp/Dockerfile
+++ b/pr-ops/mcp/outline-mcp/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+ENV PORT=3100
+EXPOSE 3100
+CMD ["npm", "start"]

--- a/pr-ops/mcp/outline-mcp/package.json
+++ b/pr-ops/mcp/outline-mcp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "pr-ops-outline-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "latest",
+    "express": "latest",
+    "zod": "latest"
+  },
+  "devDependencies": {
+    "@types/express": "latest",
+    "@types/node": "latest",
+    "typescript": "latest"
+  }
+}

--- a/pr-ops/mcp/outline-mcp/src/index.ts
+++ b/pr-ops/mcp/outline-mcp/src/index.ts
@@ -1,0 +1,153 @@
+import express from 'express';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { z } from 'zod';
+
+const port = Number(process.env.PORT || 3100);
+const outlineBaseUrl = (process.env.OUTLINE_API_URL || 'http://outline.pr-ops.svc.cluster.local:3000').replace(/\/$/, '');
+const outlineApiToken = process.env.OUTLINE_API_TOKEN;
+
+if (!outlineApiToken) {
+  throw new Error('OUTLINE_API_TOKEN is required');
+}
+
+async function outlineRequest(endpoint: string, body: Record<string, unknown> = {}) {
+  const response = await fetch(`${outlineBaseUrl}/api/${endpoint.replace(/^\/?api\/?/, '')}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${outlineApiToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  });
+  const text = await response.text();
+  let payload: unknown;
+  try {
+    payload = text ? JSON.parse(text) : null;
+  } catch {
+    payload = text;
+  }
+  if (!response.ok) {
+    throw new Error(`Outline API ${response.status}: ${typeof payload === 'string' ? payload : JSON.stringify(payload)}`);
+  }
+  return payload;
+}
+
+function asContent(value: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] };
+}
+
+function createServer() {
+  const server = new McpServer(
+    { name: 'outline-wiki', version: '0.1.1' },
+    {
+      instructions:
+        'Use Outline tools for PR knowledge-base documents, PARA collections, campaign briefs, and generated draft storage. Outline is not a task manager; tasks live in Plane.'
+    }
+  );
+
+  server.registerTool(
+    'outline_create_document',
+    {
+      title: 'Create Outline Document',
+      description: 'Create a document in Outline.',
+      inputSchema: {
+        title: z.string(),
+        text: z.string(),
+        collectionId: z.string(),
+        parentDocumentId: z.string().optional(),
+        publish: z.boolean().default(true)
+      }
+    },
+    async (input) => asContent(await outlineRequest('documents.create', input))
+  );
+
+  server.registerTool(
+    'outline_search_documents',
+    {
+      title: 'Search Outline Documents',
+      description: 'Search Outline documents by query.',
+      inputSchema: {
+        query: z.string(),
+        collectionId: z.string().optional()
+      }
+    },
+    async (input) => asContent(await outlineRequest('documents.search', input))
+  );
+
+  server.registerTool(
+    'outline_update_document',
+    {
+      title: 'Update Outline Document',
+      description: 'Update or append content to an Outline document.',
+      inputSchema: {
+        id: z.string(),
+        title: z.string().optional(),
+        text: z.string().optional(),
+        append: z.boolean().optional()
+      }
+    },
+    async (input) => asContent(await outlineRequest('documents.update', input))
+  );
+
+  server.registerTool(
+    'outline_move_document',
+    {
+      title: 'Move Outline Document',
+      description: 'Move an Outline document between collections or parents.',
+      inputSchema: {
+        id: z.string(),
+        collectionId: z.string(),
+        parentDocumentId: z.string().optional()
+      }
+    },
+    async (input) => asContent(await outlineRequest('documents.move', input))
+  );
+
+  server.registerTool(
+    'outline_list_collections',
+    {
+      title: 'List Outline Collections',
+      description: 'List Outline collections.',
+      inputSchema: {}
+    },
+    async () => asContent(await outlineRequest('collections.list'))
+  );
+
+  server.registerTool(
+    'outline_get_collection',
+    {
+      title: 'Get Outline Collection',
+      description: 'Get one Outline collection by id.',
+      inputSchema: {
+        id: z.string()
+      }
+    },
+    async (input) => asContent(await outlineRequest('collections.info', input))
+  );
+
+  return server;
+}
+
+const app = express();
+app.use(express.json({ limit: '4mb' }));
+app.get('/health', (_req, res) => res.json({ status: 'ok', service: 'outline-mcp' }));
+app.post('/mcp', async (req, res) => {
+  try {
+    const server = createServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true
+    });
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    if (!res.headersSent) {
+      res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
+    }
+  }
+});
+
+app.listen(port, () => {
+  console.log(`outline-mcp listening on :${port}`);
+});

--- a/pr-ops/mcp/outline-mcp/tsconfig.json
+++ b/pr-ops/mcp/outline-mcp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pr-ops/mcp/temporal-mcp/Dockerfile
+++ b/pr-ops/mcp/temporal-mcp/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+ENV PORT=3300
+EXPOSE 3300
+CMD ["npm", "start"]

--- a/pr-ops/mcp/temporal-mcp/package.json
+++ b/pr-ops/mcp/temporal-mcp/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "pr-ops-temporal-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "latest",
+    "@temporalio/client": "latest",
+    "express": "latest",
+    "zod": "latest"
+  },
+  "devDependencies": {
+    "@types/express": "latest",
+    "@types/node": "latest",
+    "typescript": "latest"
+  }
+}

--- a/pr-ops/mcp/temporal-mcp/src/index.ts
+++ b/pr-ops/mcp/temporal-mcp/src/index.ts
@@ -1,0 +1,163 @@
+import express from 'express';
+import { Connection, Client } from '@temporalio/client';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { z } from 'zod';
+
+const port = Number(process.env.PORT || 3300);
+const temporalAddress = process.env.TEMPORAL_ADDRESS || 'temporal-frontend.pr-ops.svc.cluster.local:7233';
+const temporalNamespace = process.env.TEMPORAL_NAMESPACE || 'pr-ops';
+
+let clientPromise: Promise<Client> | undefined;
+async function temporalClient() {
+  if (!clientPromise) {
+    clientPromise = Connection.connect({ address: temporalAddress }).then(
+      (connection) => new Client({ connection, namespace: temporalNamespace })
+    );
+  }
+  return clientPromise;
+}
+
+function asContent(value: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] };
+}
+
+function createServer() {
+  const server = new McpServer(
+    { name: 'temporal-workflows', version: '0.1.1' },
+    {
+      instructions:
+        'Use Temporal tools to start PR workflows, send human approval signals, query workflow status, and list active workflow executions.'
+    }
+  );
+
+  server.registerTool(
+    'temporal_trigger_workflow',
+    {
+      title: 'Trigger Temporal Workflow',
+      description: 'Start a workflow execution in namespace pr-ops.',
+      inputSchema: {
+        workflowType: z.string(),
+        taskQueue: z.string(),
+        workflowId: z.string(),
+        input: z.unknown().optional()
+      }
+    },
+    async ({ workflowType, taskQueue, workflowId, input }) => {
+      const client = await temporalClient();
+      const handle = await client.workflow.start(workflowType, {
+        taskQueue,
+        workflowId,
+        args: input === undefined ? [] : [input]
+      });
+      return asContent({ workflowId: handle.workflowId, firstExecutionRunId: handle.firstExecutionRunId });
+    }
+  );
+
+  server.registerTool(
+    'temporal_send_signal',
+    {
+      title: 'Send Temporal Signal',
+      description: 'Send a signal to an existing workflow execution.',
+      inputSchema: {
+        workflowId: z.string(),
+        signalName: z.string(),
+        payload: z.unknown().optional()
+      }
+    },
+    async ({ workflowId, signalName, payload }) => {
+      const client = await temporalClient();
+      const handle = client.workflow.getHandle(workflowId);
+      await handle.signal(signalName, payload);
+      return asContent({ workflowId, signalName, sent: true });
+    }
+  );
+
+  server.registerTool(
+    'temporal_query_status',
+    {
+      title: 'Query Temporal Workflow Status',
+      description: 'Describe one workflow execution.',
+      inputSchema: {
+        workflowId: z.string()
+      }
+    },
+    async ({ workflowId }) => {
+      const client = await temporalClient();
+      const handle = client.workflow.getHandle(workflowId);
+      return asContent(await handle.describe());
+    }
+  );
+
+  server.registerTool(
+    'temporal_pause_all_content',
+    {
+      title: 'Pause All Content',
+      description: 'Signal a supervisor workflow to pause all PR content work.',
+      inputSchema: {
+        reason: z.string()
+      }
+    },
+    async ({ reason }) => {
+      const client = await temporalClient();
+      const handle = client.workflow.getHandle('pr-ops-supervisor');
+      await handle.signal('PAUSE_ALL', { reason, at: new Date().toISOString() });
+      return asContent({ supervisorWorkflowId: 'pr-ops-supervisor', signalName: 'PAUSE_ALL', reason });
+    }
+  );
+
+  server.registerTool(
+    'temporal_list_running',
+    {
+      title: 'List Running Temporal Workflows',
+      description: 'List running workflow executions, optionally filtered by workflow type.',
+      inputSchema: {
+        workflowType: z.string().optional()
+      }
+    },
+    async ({ workflowType }) => {
+      const client = await temporalClient();
+      const query = workflowType
+        ? `ExecutionStatus = "Running" AND WorkflowType = "${workflowType}"`
+        : 'ExecutionStatus = "Running"';
+      const executions = [];
+      for await (const execution of client.workflow.list({ query })) {
+        executions.push(execution);
+        if (executions.length >= 50) break;
+      }
+      return asContent({ query, executions });
+    }
+  );
+
+  return server;
+}
+
+const app = express();
+app.use(express.json({ limit: '2mb' }));
+app.get('/health', async (_req, res) => {
+  try {
+    await temporalClient();
+    res.json({ status: 'ok', service: 'temporal-mcp', temporalAddress, temporalNamespace });
+  } catch (error) {
+    res.status(500).json({ status: 'error', error: error instanceof Error ? error.message : String(error) });
+  }
+});
+app.post('/mcp', async (req, res) => {
+  try {
+    const server = createServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true
+    });
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    if (!res.headersSent) {
+      res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
+    }
+  }
+});
+
+app.listen(port, () => {
+  console.log(`temporal-mcp listening on :${port}; Temporal ${temporalAddress}/${temporalNamespace}`);
+});

--- a/pr-ops/mcp/temporal-mcp/tsconfig.json
+++ b/pr-ops/mcp/temporal-mcp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pr-ops/mcp/twenty-mcp/Dockerfile
+++ b/pr-ops/mcp/twenty-mcp/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+ENV PORT=5008
+EXPOSE 5008
+CMD ["npm", "start"]

--- a/pr-ops/mcp/twenty-mcp/package.json
+++ b/pr-ops/mcp/twenty-mcp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "pr-ops-twenty-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "latest",
+    "express": "latest",
+    "zod": "latest"
+  },
+  "devDependencies": {
+    "@types/express": "latest",
+    "@types/node": "latest",
+    "typescript": "latest"
+  }
+}

--- a/pr-ops/mcp/twenty-mcp/src/index.ts
+++ b/pr-ops/mcp/twenty-mcp/src/index.ts
@@ -1,0 +1,115 @@
+import express from 'express';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { z } from 'zod';
+
+const port = Number(process.env.PORT || 5008);
+const twentyBaseUrl = (process.env.TWENTY_API_URL || 'http://twenty-crm-server.pr-ops.svc.cluster.local:3000').replace(/\/$/, '');
+const twentyApiKey = process.env.TWENTY_API_KEY;
+
+if (!twentyApiKey) {
+  throw new Error('TWENTY_API_KEY is required');
+}
+
+async function twentyRequest(path: string, init: RequestInit = {}) {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const response = await fetch(`${twentyBaseUrl}${normalizedPath}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${twentyApiKey}`,
+      'Content-Type': 'application/json',
+      ...(init.headers || {})
+    }
+  });
+  const text = await response.text();
+  let body: unknown;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  if (!response.ok) {
+    throw new Error(`Twenty API ${response.status}: ${typeof body === 'string' ? body : JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+function asContent(value: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] };
+}
+
+function createServer() {
+  const server = new McpServer(
+    { name: 'twenty-crm', version: '0.1.1' },
+    {
+      instructions:
+        'Use Twenty CRM tools for PR media contacts, opportunities, coverage, and generic Twenty API access. Prefer explicit paths returned by Twenty metadata when available.'
+    }
+  );
+
+  server.registerTool(
+    'twenty_api_request',
+    {
+      title: 'Twenty API Request',
+      description: 'Call an arbitrary Twenty REST API path using the configured API key.',
+      inputSchema: {
+        method: z.enum(['GET', 'POST', 'PATCH', 'PUT', 'DELETE']).default('GET'),
+        path: z.string().describe('Path such as /rest/people or /rest/metadata/objects'),
+        body: z.record(z.string(), z.unknown()).optional()
+      }
+    },
+    async ({ method, path, body }) =>
+      asContent(
+        await twentyRequest(path, {
+          method,
+          body: body === undefined ? undefined : JSON.stringify(body)
+        })
+      )
+  );
+
+  server.registerTool(
+    'twenty_search_metadata',
+    {
+      title: 'Twenty Metadata Search',
+      description: 'Fetch Twenty metadata objects so the conductor can discover custom PR objects and fields.',
+      inputSchema: {
+        query: z.string().optional()
+      }
+    },
+    async ({ query }) => {
+      const metadata = await twentyRequest('/rest/metadata/objects');
+      if (!query) return asContent(metadata);
+      const lower = query.toLowerCase();
+      return asContent(
+        JSON.parse(JSON.stringify(metadata)).filter?.((item: Record<string, unknown>) =>
+          JSON.stringify(item).toLowerCase().includes(lower)
+        ) ?? metadata
+      );
+    }
+  );
+
+  return server;
+}
+
+const app = express();
+app.use(express.json({ limit: '2mb' }));
+app.get('/health', (_req, res) => res.json({ status: 'ok', service: 'twenty-mcp' }));
+app.post('/mcp', async (req, res) => {
+  try {
+    const server = createServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true
+    });
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    if (!res.headersSent) {
+      res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
+    }
+  }
+});
+
+app.listen(port, () => {
+  console.log(`twenty-mcp listening on :${port}`);
+});

--- a/pr-ops/mcp/twenty-mcp/tsconfig.json
+++ b/pr-ops/mcp/twenty-mcp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- Add open-source `pr-ops/` extract: conductor-gateway + Twenty/Outline/Mattermost/Temporal MCP bridges
- Prefer xAI Grok via Responses API function calling with a **local ClusterIP MCP client** (Anthropic cloud `mcp_servers` cannot reach `*.svc.cluster.local`)
- Anthropic Haiku remains fallback on the same local tool loop; `ENABLE_ANTHROPIC_REMOTE_MCP` is experimental-only
- MCP servers create a fresh `McpServer` per request (stateless Streamable HTTP); `PLANE_MCP_URL=off` until Plane MCP exists
- Images: `ghcr.io/connectplatform/ring/pr-ops/*:latest` (already published from Ringdom launch)

## Test plan
- [ ] `cd pr-ops/conductor && npm install && npm run build`
- [ ] With `XAI_API_KEY` + reachable MCP URLs, `GET /health` shows `enableMcpTools: true` and non-zero `mcpToolCount`
- [ ] `POST /boss` with a Twenty metadata prompt returns `tool_trace` with `twenty-crm__twenty_search_metadata`
- [ ] Confirm MCP Services stay ClusterIP-only (no public Ingress)


Made with [Cursor](https://cursor.com)